### PR TITLE
Only return user if presence is true

### DIFF
--- a/lib/ahoy/stores/base_store.rb
+++ b/lib/ahoy/stores/base_store.rb
@@ -31,7 +31,7 @@ module Ahoy
       end
 
       def user
-        @user ||= (controller.respond_to?(:current_user) && controller.current_user) || (controller.respond_to?(:current_resource_owner, true) && controller.send(:current_resource_owner)) || nil
+        @user ||= (controller.respond_to?(:current_user) && controller.current_user.presence) || (controller.respond_to?(:current_resource_owner, true) && controller.send(:current_resource_owner)) || nil
       end
 
       def exclude?


### PR DESCRIPTION
We have a use case where we're using a null object pattern for our `current_user` method (ie, sending `current_user` returns a `User` if someone is logged in, and a `LoggedOutUser` if logged out.)

This breaks with ahoy, because the user method checks only for truthiness, rather than presence.

Is it fair to put a presence check in here? Do we need to use the ruby version
```
controller.current_user.present? : controller.current_user : nil
```
instead of rails's `presence`?